### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/StandardTenor.java
+++ b/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/StandardTenor.java
@@ -95,6 +95,9 @@ public final class StandardTenor {
 
     public static final Tenor T_50Y = new Tenor(50, TenorCode.YEAR);
 
+    private StandardTenor() {
+    }
+
     public static List<Tenor> getAll() {
         return ALL;
     }
@@ -125,8 +128,6 @@ public final class StandardTenor {
         ALL = Collections.unmodifiableList(list);
     }
 
-    private StandardTenor() {
-    }
 }
 
 /*

--- a/fxcalc/src/main/java/net/objectlab/kit/fxcalc/StandardMajorCurrencyRanking.java
+++ b/fxcalc/src/main/java/net/objectlab/kit/fxcalc/StandardMajorCurrencyRanking.java
@@ -22,11 +22,12 @@ import java.util.Arrays;
 public final class StandardMajorCurrencyRanking extends MajorCurrencyRankingImpl {
     private static final MajorCurrencyRanking DEFAULT = new StandardMajorCurrencyRanking();
 
+    private StandardMajorCurrencyRanking() {
+        super(Arrays.asList("EUR", "GBP", "AUD", "NZD", "USD", "CAD", "CHF", "NOK", "SEK", "JPY"));
+    }
+
     public static MajorCurrencyRanking getDefault() {
         return DEFAULT;
     }
 
-    private StandardMajorCurrencyRanking() {
-        super(Arrays.asList("EUR", "GBP", "AUD", "NZD", "USD", "CAD", "CHF", "NOK", "SEK", "JPY"));
-    }
 }

--- a/portfolio/src/main/java/net/objectlab/kit/pf/validator/Results.java
+++ b/portfolio/src/main/java/net/objectlab/kit/pf/validator/Results.java
@@ -14,11 +14,11 @@ import org.apache.commons.lang.StringUtils;
 public class Results implements ValidationResults {
     private final List<ValidatedPortfolioLineImpl> lines = new ArrayList<>();
 
+    private final List<RuleIssue> issues = new ArrayList<>();
+
     public Results(final ExistingPortfolio p) {
         p.getLines().forEach(t -> lines.add(new ValidatedPortfolioLineImpl(t, this)));
     }
-
-    private final List<RuleIssue> issues = new ArrayList<>();
 
     @Override
     public boolean isValid() {

--- a/utils/src/main/java/net/objectlab/kit/util/Average.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Average.java
@@ -55,6 +55,11 @@ public final class Average implements Serializable {
         determineMinMax(start);
     }
 
+    public Average(final int scale) {
+        final BigDecimal bd = new BigDecimal(0);
+        sum = new Total(bd.setScale(scale));
+    }
+
     private void determineMinMax(final BigDecimal value) {
         if (maximum == null || BigDecimalUtil.compareTo(value, maximum) == 1) {
             maximum = value;
@@ -62,11 +67,6 @@ public final class Average implements Serializable {
         if (minimum == null || BigDecimalUtil.compareTo(value, minimum) == -1) {
             minimum = value;
         }
-    }
-
-    public Average(final int scale) {
-        final BigDecimal bd = new BigDecimal(0);
-        sum = new Total(bd.setScale(scale));
     }
 
     public void add(final BigDecimal... values) {

--- a/utils/src/main/java/net/objectlab/kit/util/BigDecimalUtil.java
+++ b/utils/src/main/java/net/objectlab/kit/util/BigDecimalUtil.java
@@ -46,6 +46,9 @@ public final class BigDecimalUtil {
     private static final int MAX_SCALE_FOR_INVERSE = 20;
     private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance();
 
+    private static final BigDecimal SQRT_DIG = new BigDecimal(8);
+    private static final BigDecimal SQRT_PRE = new BigDecimal(10).pow(SQRT_DIG.intValue());
+
     private BigDecimalUtil() {
     }
 
@@ -766,9 +769,6 @@ public final class BigDecimalUtil {
     public static BigDecimal decimalPart(final BigDecimal val) {
         return BigDecimalUtil.subtract(val, val.setScale(0, BigDecimal.ROUND_DOWN));
     }
-
-    private static final BigDecimal SQRT_DIG = new BigDecimal(8);
-    private static final BigDecimal SQRT_PRE = new BigDecimal(10).pow(SQRT_DIG.intValue());
 
     /**
      * Private utility method used to compute the square root of a BigDecimal.

--- a/utils/src/main/java/net/objectlab/kit/util/Pair.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Pair.java
@@ -44,16 +44,16 @@ public class Pair<E1, E2> implements Serializable {
     private E1 element1;
     private E2 element2;
 
-    public static <E1, E2> Pair<E1, E2> create(final E1 element1, final E2 element2) {
-        return new Pair<E1, E2>(element1, element2);
-    }
-
     public Pair(final E1 element1, final E2 element2) {
         this.element1 = element1;
         this.element2 = element2;
     }
 
     public Pair() {
+    }
+
+    public static <E1, E2> Pair<E1, E2> create(final E1 element1, final E2 element2) {
+        return new Pair<E1, E2>(element1, element2);
     }
 
     public E1 getElement1() {

--- a/utils/src/main/java/net/objectlab/kit/util/Quadruplet.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Quadruplet.java
@@ -52,20 +52,20 @@ public class Quadruplet<E1, E2, E3, E4> implements Serializable {
     private E3 element3;
     private E4 element4;
 
-    public E1 getElement1() {
-        return element1;
-    }
-
-    public static <E1, E2, E3, E4> Quadruplet<E1, E2, E3, E4> create(final E1 element1, final E2 element2, final E3 element3, final E4 element4) {
-        return new Quadruplet<E1, E2, E3, E4>(element1, element2, element3, element4);
-    }
-
     public Quadruplet(final E1 element1, final E2 element2, final E3 element3, final E4 element4) {
         super();
         this.element1 = element1;
         this.element2 = element2;
         this.element3 = element3;
         this.element4 = element4;
+    }
+
+    public E1 getElement1() {
+        return element1;
+    }
+
+    public static <E1, E2, E3, E4> Quadruplet<E1, E2, E3, E4> create(final E1 element1, final E2 element2, final E3 element3, final E4 element4) {
+        return new Quadruplet<E1, E2, E3, E4>(element1, element2, element3, element4);
     }
 
     public void setElement1(final E1 element1) {

--- a/utils/src/main/java/net/objectlab/kit/util/Triplet.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Triplet.java
@@ -51,19 +51,19 @@ public class Triplet<E1, E2, E3> implements Serializable {
     private E2 element2;
     private E3 element3;
 
+    public Triplet(final E1 element1, final E2 element2, final E3 element3) {
+        super();
+        this.element1 = element1;
+        this.element2 = element2;
+        this.element3 = element3;
+    }
+
     public E1 getElement1() {
         return element1;
     }
 
     public static <E1, E2, E3> Triplet<E1, E2, E3> create(final E1 element1, final E2 element2, final E3 element3) {
         return new Triplet<E1, E2, E3>(element1, element2, element3);
-    }
-
-    public Triplet(final E1 element1, final E2 element2, final E3 element3) {
-        super();
-        this.element1 = element1;
-        this.element2 = element2;
-        this.element3 = element3;
     }
 
     public void setElement1(final E1 element1) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat