### PR TITLE
squid:S2325 - private methods that don't access instance data should …

### DIFF
--- a/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/CurrencyDateCalculatorBuilder.java
+++ b/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/CurrencyDateCalculatorBuilder.java
@@ -102,7 +102,7 @@ public class CurrencyDateCalculatorBuilder<E> {
         }
     }
 
-    private void append(StringBuilder b, String string) {
+    private static void append(StringBuilder b, String string) {
         if (b.length() > 0) {
             b.append(",");
         }

--- a/datecalc-jdk/src/main/java/net/objectlab/kit/datecalc/jdk/CalendarIMMDateCalculator.java
+++ b/datecalc-jdk/src/main/java/net/objectlab/kit/datecalc/jdk/CalendarIMMDateCalculator.java
@@ -155,7 +155,7 @@ public class CalendarIMMDateCalculator extends AbstractIMMDateCalculator<Calenda
     //
     // -----------------------------------------------------------------------
 
-    private boolean isIMMMonth(final Calendar cal) {
+    private static boolean isIMMMonth(final Calendar cal) {
         final int month = cal.get(MONTH);
 
         switch (month) {
@@ -174,7 +174,7 @@ public class CalendarIMMDateCalculator extends AbstractIMMDateCalculator<Calenda
      *
      * @param cal
      */
-    private void moveToIMMDay(final Calendar cal) {
+    private static void moveToIMMDay(final Calendar cal) {
         cal.set(DAY_OF_MONTH, 1);
 
         // go to 1st wed

--- a/datecalc-jdk/src/main/java/net/objectlab/kit/datecalc/jdk/CalendarPeriodCountCalculator.java
+++ b/datecalc-jdk/src/main/java/net/objectlab/kit/datecalc/jdk/CalendarPeriodCountCalculator.java
@@ -129,7 +129,7 @@ public class CalendarPeriodCountCalculator implements PeriodCountCalculator<Cale
     //
     // -----------------------------------------------------------------------
 
-    private int dayDiff(final Calendar start, final Calendar end) {
+    private static int dayDiff(final Calendar start, final Calendar end) {
         final long diff = Math.abs(start.getTimeInMillis() - end.getTimeInMillis());
         final double dayDiff = (double) diff / MILLIS_IN_DAY;
         return (int) Math.round(dayDiff);

--- a/datecalc-jdk/src/main/java/net/objectlab/kit/datecalc/jdk/DateIMMDateCalculator.java
+++ b/datecalc-jdk/src/main/java/net/objectlab/kit/datecalc/jdk/DateIMMDateCalculator.java
@@ -74,7 +74,7 @@ public class DateIMMDateCalculator extends AbstractIMMDateCalculator<Date> {
         return DELEGATE.isIMMDate(Utils.getCal(date));
     }
 
-    private List<Date> buildList(final List<Calendar> dates) {
+    private static List<Date> buildList(final List<Calendar> dates) {
         final List<Date> imms = new ArrayList<Date>();
         for (final Calendar date : dates) {
             imms.add(date.getTime());

--- a/datecalc-jdk8/src/main/java/net/objectlab/kit/datecalc/jdk8/LocalDateIMMDateCalculator.java
+++ b/datecalc-jdk8/src/main/java/net/objectlab/kit/datecalc/jdk8/LocalDateIMMDateCalculator.java
@@ -175,7 +175,7 @@ public class LocalDateIMMDateCalculator extends AbstractIMMDateCalculator<LocalD
      *            the start date
      * @return the 3rd Wednesday of the month
      */
-    private LocalDate calculate3rdWednesday(final LocalDate original) {
+    private static LocalDate calculate3rdWednesday(final LocalDate original) {
         return original.with(TemporalAdjusters.firstInMonth(DayOfWeek.WEDNESDAY)).plusWeeks(2);
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat