### PR TITLE
squid:S3052 - Fields should not be initialized to default values

### DIFF
--- a/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/AbstractDateCalculator.java
+++ b/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/AbstractDateCalculator.java
@@ -70,7 +70,7 @@ public abstract class AbstractDateCalculator<E> implements DateCalculator<E> {
 
     private HolidayHandler<E> holidayHandler;
 
-    private int currentIncrement = 0;
+    private int currentIncrement;
 
     protected AbstractDateCalculator(final String name, final HolidayCalendar<E> holidayCalendar, final HolidayHandler<E> holidayHandler) {
         this.name = name;

--- a/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/CurrencyDateCalculatorBuilder.java
+++ b/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/CurrencyDateCalculatorBuilder.java
@@ -37,7 +37,7 @@ public class CurrencyDateCalculatorBuilder<E> {
     private WorkingWeek ccy2Week;
     private WorkingWeek crossCcyWeek;
     private CurrencyCalculatorConfig currencyCalculatorConfig;
-    private boolean brokenDateAllowed = false;
+    private boolean brokenDateAllowed;
     private boolean adjustStartDateWithCurrencyPair = true;
     private SpotLag spotLag = SpotLag.T_2;
 

--- a/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/DefaultHolidayCalendar.java
+++ b/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/DefaultHolidayCalendar.java
@@ -55,9 +55,9 @@ public class DefaultHolidayCalendar<E> implements HolidayCalendar<E> {
      */
     private Map<String, E> holidays;
 
-    private E earlyBoundary = null;
+    private E earlyBoundary;
 
-    private E lateBoundary = null;
+    private E lateBoundary;
 
     public DefaultHolidayCalendar() {
         super();

--- a/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/Tenor.java
+++ b/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/Tenor.java
@@ -43,7 +43,7 @@ import java.io.Serializable;
  */
 public class Tenor implements Serializable {
     private static final long serialVersionUID = 1L;
-    private int units = 0;
+    private int units;
 
     private final TenorCode code;
 

--- a/utils/src/main/java/net/objectlab/kit/collections/ReadOnlyExpiringCollectionBuilder.java
+++ b/utils/src/main/java/net/objectlab/kit/collections/ReadOnlyExpiringCollectionBuilder.java
@@ -15,7 +15,7 @@ import net.objectlab.kit.util.PeriodBuilder;
 public class ReadOnlyExpiringCollectionBuilder {
     private long expiryTimeoutMilliseconds = -1;
     private boolean reloadOnExpiry = true;
-    private boolean reloadWhenExpired = false;
+    private boolean reloadWhenExpired;
     private boolean loadOnFirstAccess = true;
     private String id;
     private TimeProvider timeProvider;

--- a/utils/src/main/java/net/objectlab/kit/console/ConsoleMenu.java
+++ b/utils/src/main/java/net/objectlab/kit/console/ConsoleMenu.java
@@ -417,7 +417,7 @@ public class ConsoleMenu {
      * This class attempts to erase characters echoed to the console.
      */
     static class PasswordHidingThread extends Thread {
-        private boolean stop = false;
+        private boolean stop;
 
         private final String prompt;
 

--- a/utils/src/main/java/net/objectlab/kit/util/Average.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Average.java
@@ -45,7 +45,7 @@ public final class Average implements Serializable {
     private Total sum = new Total(BigDecimal.ZERO, 8);
     private BigDecimal maximum;
     private BigDecimal minimum;
-    private int count = 0;
+    private int count;
 
     public Average() {
     }

--- a/utils/src/main/java/net/objectlab/kit/util/PeriodBuilder.java
+++ b/utils/src/main/java/net/objectlab/kit/util/PeriodBuilder.java
@@ -16,12 +16,12 @@ public class PeriodBuilder {
     private static final long M_IN_1_HOUR = 60L;
     private static final long H_IN_1_DAY = 24L;
     private static final long D_IN_1_WEEK = 7L;
-    private int weeks = 0;
-    private int days = 0;
-    private int hours = 0;
-    private int minutes = 0;
-    private int seconds = 0;
-    private long milliseconds = 0;
+    private int weeks;
+    private int days;
+    private int hours;
+    private int minutes;
+    private int seconds;
+    private long milliseconds;
 
     public long calculateMilliseconds() {
         return milliseconds //

--- a/utils/src/main/java/net/objectlab/kit/util/Total.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Total.java
@@ -43,7 +43,7 @@ import java.math.BigDecimal;
 public class Total implements Serializable {
     private static final long serialVersionUID = -8583271171731930344L;
     private BigDecimal value = BigDecimal.ZERO;
-    private int count = 0;
+    private int count;
 
     public Total() {
         this(BigDecimal.ZERO, 0);

--- a/utils/src/main/java/net/objectlab/kit/util/WeightedAverage.java
+++ b/utils/src/main/java/net/objectlab/kit/util/WeightedAverage.java
@@ -43,7 +43,7 @@ public class WeightedAverage implements Serializable {
     private static final long serialVersionUID = 4687472725716492770L;
     private final Total total = new Total();
     private final Total totalExpanded = new Total();
-    private int count = 0;
+    private int count;
     private final boolean includeZeros;
     private BigDecimal maximum;
     private BigDecimal minimum;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3052 - Fields should not be initialized to default values

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat