### PR TITLE
squid:S2293 - The diamond operator ("<>") should be used

### DIFF
--- a/datecalc-jdk8/src/main/java/net/objectlab/kit/datecalc/jdk8/LocalDateCalculator.java
+++ b/datecalc-jdk8/src/main/java/net/objectlab/kit/datecalc/jdk8/LocalDateCalculator.java
@@ -55,7 +55,7 @@ public class LocalDateCalculator extends AbstractDateCalculator<LocalDate> {
     private Jdk8WorkingWeek workingWeek = Jdk8WorkingWeek.DEFAULT;
 
     public LocalDateCalculator() {
-        this(null, null, new DefaultHolidayCalendar<LocalDate>(Collections.emptySet()), null);
+        this(null, null, new DefaultHolidayCalendar<>(Collections.emptySet()), null);
     }
 
     public LocalDateCalculator(final String name, final LocalDate startDate, final HolidayCalendar<LocalDate> holidayCalendar,

--- a/datecalc-jdk8/src/main/java/net/objectlab/kit/datecalc/jdk8/LocalDateIMMDateCalculator.java
+++ b/datecalc-jdk8/src/main/java/net/objectlab/kit/datecalc/jdk8/LocalDateIMMDateCalculator.java
@@ -73,7 +73,7 @@ public class LocalDateIMMDateCalculator extends AbstractIMMDateCalculator<LocalD
      */
     @Override
     public List<LocalDate> getIMMDates(final LocalDate start, final LocalDate end, final IMMPeriod period) {
-        final List<LocalDate> dates = new ArrayList<LocalDate>();
+        final List<LocalDate> dates = new ArrayList<>();
 
         LocalDate date = start;
         while (true) {

--- a/datecalc-jdk8/src/test/java/net/objectlab/kit/datecalc/jdk8/DefaultHolidayCalendarTest.java
+++ b/datecalc-jdk8/src/test/java/net/objectlab/kit/datecalc/jdk8/DefaultHolidayCalendarTest.java
@@ -10,21 +10,21 @@ import net.objectlab.kit.datecalc.common.HolidayCalendar;
 
 public class DefaultHolidayCalendarTest extends TestCase {
     public void testGetHolidays() {
-        final Set<LocalDate> holidays = new HashSet<LocalDate>();
+        final Set<LocalDate> holidays = new HashSet<>();
         holidays.add(LocalDate.parse("2009-04-22"));
         holidays.add(LocalDate.parse("2010-04-22"));
 
-        final HolidayCalendar<LocalDate> holidayCalendar = new DefaultHolidayCalendar<LocalDate>(holidays, LocalDate.parse("2009-01-01"),
+        final HolidayCalendar<LocalDate> holidayCalendar = new DefaultHolidayCalendar<>(holidays, LocalDate.parse("2009-01-01"),
                 LocalDate.parse("2009-12-01"));
         assertTrue(holidayCalendar.getHolidays().size() == 2);
     }
 
     public void testIsHoliday() {
-        final Set<LocalDate> holidays = new HashSet<LocalDate>();
+        final Set<LocalDate> holidays = new HashSet<>();
         final LocalDate holiday = LocalDate.parse("2009-04-22");
         holidays.add(holiday);
 
-        final HolidayCalendar<LocalDate> holidayCalendar = new DefaultHolidayCalendar<LocalDate>(holidays, LocalDate.parse("2009-01-01"),
+        final HolidayCalendar<LocalDate> holidayCalendar = new DefaultHolidayCalendar<>(holidays, LocalDate.parse("2009-01-01"),
                 LocalDate.parse("2009-12-01"));
 
         final LocalDate testHoliday = LocalDate.parse("2009-04-22");

--- a/portfolio/src/test/java/net/objectlab/kit/pf/ucits/BasicUcitsSteps.java
+++ b/portfolio/src/test/java/net/objectlab/kit/pf/ucits/BasicUcitsSteps.java
@@ -52,7 +52,7 @@ public class BasicUcitsSteps {
         portfolio.setPortfolioCcy(ccy);
 
         final List<BasicLine> details = dataTable.asList(BasicLine.class);
-        final List<ExistingPortfolioLine> lines = new ArrayList<ExistingPortfolioLine>();
+        final List<ExistingPortfolioLine> lines = new ArrayList<>();
         lines.addAll(details);
         portfolio.setLines(lines);
         portfolio.setPortfolioValue(lines.stream().map(t -> t.getValueInPortfolioCcy()).reduce(BigDecimal.ZERO, (a, b) -> b != null ? a.add(b) : a));

--- a/utils/src/main/java/net/objectlab/kit/collections/DefaultMapBuilder.java
+++ b/utils/src/main/java/net/objectlab/kit/collections/DefaultMapBuilder.java
@@ -18,7 +18,7 @@ import net.objectlab.kit.util.Pair;
  *
  */
 public class DefaultMapBuilder<K, V> implements MapBuilder<K, V> {
-    private final List<Pair<K, V>> entries = new ArrayList<Pair<K, V>>();
+    private final List<Pair<K, V>> entries = new ArrayList<>();
     private final String id;
 
     public DefaultMapBuilder(final String id) {
@@ -35,7 +35,7 @@ public class DefaultMapBuilder<K, V> implements MapBuilder<K, V> {
      */
     @Override
     public DefaultMapBuilder<K, V> put(final K key, final V value) {
-        entries.add(new Pair<K, V>(key, value));
+        entries.add(new Pair<>(key, value));
         return this;
     }
 
@@ -65,9 +65,9 @@ public class DefaultMapBuilder<K, V> implements MapBuilder<K, V> {
     private static <K, V> Map<K, V> fromEntryList(final List<Pair<K, V>> entries) {
         final int size = entries.size();
         if (size == 0) {
-            return new HashMap<K, V>();
+            return new HashMap<>();
         }
-        final Map<K, V> m = new HashMap<K, V>();
+        final Map<K, V> m = new HashMap<>();
         for (final Pair<K, V> entry : entries) {
             m.put(entry.getElement1(), entry.getElement2());
         }

--- a/utils/src/main/java/net/objectlab/kit/collections/DefaultSetBuilder.java
+++ b/utils/src/main/java/net/objectlab/kit/collections/DefaultSetBuilder.java
@@ -12,7 +12,7 @@ import java.util.Set;
  *
  */
 public class DefaultSetBuilder<T> implements SetBuilder<T> {
-    private final Set<T> set = new HashSet<T>();
+    private final Set<T> set = new HashSet<>();
     private final String id;
 
     public DefaultSetBuilder(final String id) {
@@ -36,6 +36,6 @@ public class DefaultSetBuilder<T> implements SetBuilder<T> {
     }
 
     Set<T> build() {
-        return new HashSet<T>(set);
+        return new HashSet<>(set);
     }
 }

--- a/utils/src/main/java/net/objectlab/kit/collections/ReadOnlyExpiringHashMap.java
+++ b/utils/src/main/java/net/objectlab/kit/collections/ReadOnlyExpiringHashMap.java
@@ -14,7 +14,7 @@ import java.util.Set;
  */
 public class ReadOnlyExpiringHashMap<K, V> extends AbstractReadOnlyExpiringCollection implements ReadOnlyExpiringMap<K, V> {
     private static final String COLLECTION_IS_IMMUTABLE = "Collection is immutable";
-    private Map<K, V> delegate = new HashMap<K, V>();
+    private Map<K, V> delegate = new HashMap<>();
     private final MapLoader<K, V> loader;
 
     public ReadOnlyExpiringHashMap(final ReadOnlyExpiringHashMapBuilder<K, V> builder) {
@@ -30,7 +30,7 @@ public class ReadOnlyExpiringHashMap<K, V> extends AbstractReadOnlyExpiringColle
 
     @Override
     protected void doLoad() {
-        final DefaultMapBuilder<K, V> builder = new DefaultMapBuilder<K, V>(getId());
+        final DefaultMapBuilder<K, V> builder = new DefaultMapBuilder<>(getId());
         loader.load(builder);
         delegate = builder.build();
     }

--- a/utils/src/main/java/net/objectlab/kit/collections/ReadOnlyExpiringHashSet.java
+++ b/utils/src/main/java/net/objectlab/kit/collections/ReadOnlyExpiringHashSet.java
@@ -14,7 +14,7 @@ import java.util.Set;
  */
 public class ReadOnlyExpiringHashSet<T> extends AbstractReadOnlyExpiringCollection implements ReadOnlyExpiringSet<T> {
     private final SetLoader<T> loader;
-    private Set<T> delegate = new HashSet<T>();
+    private Set<T> delegate = new HashSet<>();
 
     public ReadOnlyExpiringHashSet(final ReadOnlyExpiringHashSetBuilder<T> builder) {
         this.loader = builder.getLoader();
@@ -29,7 +29,7 @@ public class ReadOnlyExpiringHashSet<T> extends AbstractReadOnlyExpiringCollecti
 
     @Override
     protected void doLoad() {
-        final DefaultSetBuilder<T> builder = new DefaultSetBuilder<T>(getId());
+        final DefaultSetBuilder<T> builder = new DefaultSetBuilder<>(getId());
         loader.load(builder);
         delegate = builder.build();
     }

--- a/utils/src/main/java/net/objectlab/kit/console/ConsoleMenu.java
+++ b/utils/src/main/java/net/objectlab/kit/console/ConsoleMenu.java
@@ -63,11 +63,11 @@ public class ConsoleMenu {
     // ~ Instance fields
     // ------------------------------------------------------------------------------------------------
 
-    private final List<String> menu = new ArrayList<String>();
+    private final List<String> menu = new ArrayList<>();
 
-    private final List<String> methods = new ArrayList<String>();
+    private final List<String> methods = new ArrayList<>();
 
-    private final List<Boolean> askForRepeat = new ArrayList<Boolean>();
+    private final List<Boolean> askForRepeat = new ArrayList<>();
 
     private final Repeater target;
 

--- a/utils/src/main/java/net/objectlab/kit/util/Pair.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Pair.java
@@ -53,7 +53,7 @@ public class Pair<E1, E2> implements Serializable {
     }
 
     public static <E1, E2> Pair<E1, E2> create(final E1 element1, final E2 element2) {
-        return new Pair<E1, E2>(element1, element2);
+        return new Pair<>(element1, element2);
     }
 
     public E1 getElement1() {

--- a/utils/src/main/java/net/objectlab/kit/util/Quadruplet.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Quadruplet.java
@@ -65,7 +65,7 @@ public class Quadruplet<E1, E2, E3, E4> implements Serializable {
     }
 
     public static <E1, E2, E3, E4> Quadruplet<E1, E2, E3, E4> create(final E1 element1, final E2 element2, final E3 element3, final E4 element4) {
-        return new Quadruplet<E1, E2, E3, E4>(element1, element2, element3, element4);
+        return new Quadruplet<>(element1, element2, element3, element4);
     }
 
     public void setElement1(final E1 element1) {

--- a/utils/src/main/java/net/objectlab/kit/util/Triplet.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Triplet.java
@@ -63,7 +63,7 @@ public class Triplet<E1, E2, E3> implements Serializable {
     }
 
     public static <E1, E2, E3> Triplet<E1, E2, E3> create(final E1 element1, final E2 element2, final E3 element3) {
-        return new Triplet<E1, E2, E3>(element1, element2, element3);
+        return new Triplet<>(element1, element2, element3);
     }
 
     public void setElement1(final E1 element1) {

--- a/utils/src/main/java/net/objectlab/kit/util/Util.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Util.java
@@ -68,7 +68,7 @@ public final class Util {
         }
 
         final StringTokenizer tok = new StringTokenizer(str, delimiter);
-        final List<String> list = new ArrayList<String>();
+        final List<String> list = new ArrayList<>();
 
         while (tok.hasMoreElements()) {
             list.add(StringUtil.trim(tok.nextToken()));

--- a/utils/src/test/java/net/objectlab/kit/collections/ReadOnlyExpiringHashMapTest.java
+++ b/utils/src/test/java/net/objectlab/kit/collections/ReadOnlyExpiringHashMapTest.java
@@ -28,7 +28,7 @@ public class ReadOnlyExpiringHashMapTest implements MapLoader<String, Integer>, 
 
     @Test
     public void basicConstructorNoReload() {
-        final ReadOnlyExpiringHashMapBuilder<String, Integer> builder = new ReadOnlyExpiringHashMapBuilder<String, Integer>(this);
+        final ReadOnlyExpiringHashMapBuilder<String, Integer> builder = new ReadOnlyExpiringHashMapBuilder<>(this);
         builder.expiryTimeoutMilliseconds(1000);
         builder.loadOnFirstAccess(true);
         builder.reloadOnExpiry(false);
@@ -36,7 +36,7 @@ public class ReadOnlyExpiringHashMapTest implements MapLoader<String, Integer>, 
         builder.timeProvider(this);
         builder.id("Greetings");
 
-        final ReadOnlyExpiringMap<String, Integer> ims = new ReadOnlyExpiringHashMap<String, Integer>(builder);
+        final ReadOnlyExpiringMap<String, Integer> ims = new ReadOnlyExpiringHashMap<>(builder);
 
         assertEquals("Should not call load until called", 0, reloadCount);
 
@@ -73,7 +73,7 @@ public class ReadOnlyExpiringHashMapTest implements MapLoader<String, Integer>, 
 
     @Test
     public void basicConstructorWithReloadWhenCalled() {
-        final ReadOnlyExpiringHashMapBuilder<String, Integer> builder = new ReadOnlyExpiringHashMapBuilder<String, Integer>(this);
+        final ReadOnlyExpiringHashMapBuilder<String, Integer> builder = new ReadOnlyExpiringHashMapBuilder<>(this);
         builder.expiryTimeoutMilliseconds(1000);
         builder.loadOnFirstAccess(true);
         builder.reloadOnExpiry(false);
@@ -81,7 +81,7 @@ public class ReadOnlyExpiringHashMapTest implements MapLoader<String, Integer>, 
         builder.timeProvider(this);
         builder.id("Greetings");
 
-        final ReadOnlyExpiringMap<String, Integer> ims = new ReadOnlyExpiringHashMap<String, Integer>(builder);
+        final ReadOnlyExpiringMap<String, Integer> ims = new ReadOnlyExpiringHashMap<>(builder);
 
         assertEquals("Should not call load until called", 0, reloadCount);
 
@@ -120,7 +120,7 @@ public class ReadOnlyExpiringHashMapTest implements MapLoader<String, Integer>, 
 
     @Test
     public void basicConstructorWithImmediateLoadAndWhenExpired() {
-        final ReadOnlyExpiringHashMapBuilder<String, Integer> builder = new ReadOnlyExpiringHashMapBuilder<String, Integer>(this);
+        final ReadOnlyExpiringHashMapBuilder<String, Integer> builder = new ReadOnlyExpiringHashMapBuilder<>(this);
         builder.expiryTimeoutMilliseconds(1000);
         builder.loadOnFirstAccess(false);
         builder.reloadOnExpiry(false);
@@ -128,7 +128,7 @@ public class ReadOnlyExpiringHashMapTest implements MapLoader<String, Integer>, 
         builder.timeProvider(this);
         builder.id("Greetings");
 
-        final ReadOnlyExpiringMap<String, Integer> ims = new ReadOnlyExpiringHashMap<String, Integer>(builder);
+        final ReadOnlyExpiringMap<String, Integer> ims = new ReadOnlyExpiringHashMap<>(builder);
 
         assertEquals("Should not call load until called", 1, reloadCount);
 
@@ -167,7 +167,7 @@ public class ReadOnlyExpiringHashMapTest implements MapLoader<String, Integer>, 
 
     @Test
     public void basicConstructorWithReloadOnExpiry() {
-        final ReadOnlyExpiringHashMapBuilder<String, Integer> builder = new ReadOnlyExpiringHashMapBuilder<String, Integer>(this);
+        final ReadOnlyExpiringHashMapBuilder<String, Integer> builder = new ReadOnlyExpiringHashMapBuilder<>(this);
         builder.expiryTimeoutMilliseconds(1000);
         builder.loadOnFirstAccess(false);
         builder.reloadOnExpiry(true);
@@ -175,7 +175,7 @@ public class ReadOnlyExpiringHashMapTest implements MapLoader<String, Integer>, 
         builder.timeProvider(this);
         builder.id("Greetings");
 
-        final ReadOnlyExpiringMap<String, Integer> ims = new ReadOnlyExpiringHashMap<String, Integer>(builder);
+        final ReadOnlyExpiringMap<String, Integer> ims = new ReadOnlyExpiringHashMap<>(builder);
 
         assertEquals("Should not call load until called", 1, reloadCount);
 

--- a/utils/src/test/java/net/objectlab/kit/collections/ReadOnlyExpiringHashSetTest.java
+++ b/utils/src/test/java/net/objectlab/kit/collections/ReadOnlyExpiringHashSetTest.java
@@ -27,7 +27,7 @@ public class ReadOnlyExpiringHashSetTest implements SetLoader<String>, TimeProvi
 
     @Test
     public void basicConstructorNoReload() {
-        final ReadOnlyExpiringHashSetBuilder<String> builder = new ReadOnlyExpiringHashSetBuilder<String>(this);
+        final ReadOnlyExpiringHashSetBuilder<String> builder = new ReadOnlyExpiringHashSetBuilder<>(this);
         builder.expiryTimeoutMilliseconds(1000);
         builder.loadOnFirstAccess(true);
         builder.reloadOnExpiry(false);
@@ -35,7 +35,7 @@ public class ReadOnlyExpiringHashSetTest implements SetLoader<String>, TimeProvi
         builder.timeProvider(this);
         builder.id("Greetings");
 
-        final ReadOnlyExpiringSet<String> ims = new ReadOnlyExpiringHashSet<String>(builder);
+        final ReadOnlyExpiringSet<String> ims = new ReadOnlyExpiringHashSet<>(builder);
         assertEquals("Should not call load until called", 0, reloadCount);
 
         assertFalse(ims.isEmpty());
@@ -65,7 +65,7 @@ public class ReadOnlyExpiringHashSetTest implements SetLoader<String>, TimeProvi
 
     @Test
     public void basicConstructorWithReloadWhenCalled() {
-        final ReadOnlyExpiringHashSetBuilder<String> builder = new ReadOnlyExpiringHashSetBuilder<String>(this);
+        final ReadOnlyExpiringHashSetBuilder<String> builder = new ReadOnlyExpiringHashSetBuilder<>(this);
         builder.expiryTimeoutMilliseconds(1000);
         builder.loadOnFirstAccess(true);
         builder.reloadOnExpiry(false);
@@ -73,7 +73,7 @@ public class ReadOnlyExpiringHashSetTest implements SetLoader<String>, TimeProvi
         builder.timeProvider(this);
         builder.id("Greetings");
 
-        final ReadOnlyExpiringSet<String> ims = new ReadOnlyExpiringHashSet<String>(builder);
+        final ReadOnlyExpiringSet<String> ims = new ReadOnlyExpiringHashSet<>(builder);
 
         assertEquals("Should not call load until called", 0, reloadCount);
 
@@ -104,7 +104,7 @@ public class ReadOnlyExpiringHashSetTest implements SetLoader<String>, TimeProvi
 
     @Test
     public void basicConstructorWithImmediateLoadAndWhenExpired() {
-        final ReadOnlyExpiringHashSetBuilder<String> builder = new ReadOnlyExpiringHashSetBuilder<String>(this);
+        final ReadOnlyExpiringHashSetBuilder<String> builder = new ReadOnlyExpiringHashSetBuilder<>(this);
         builder.expiryTimeoutMilliseconds(1000);
         builder.loadOnFirstAccess(false);
         builder.reloadOnExpiry(false);
@@ -112,7 +112,7 @@ public class ReadOnlyExpiringHashSetTest implements SetLoader<String>, TimeProvi
         builder.timeProvider(this);
         builder.id("Greetings");
 
-        final ReadOnlyExpiringSet<String> ims = new ReadOnlyExpiringHashSet<String>(builder);
+        final ReadOnlyExpiringSet<String> ims = new ReadOnlyExpiringHashSet<>(builder);
 
         assertEquals("Should call load immediately", 1, reloadCount);
 
@@ -144,7 +144,7 @@ public class ReadOnlyExpiringHashSetTest implements SetLoader<String>, TimeProvi
 
     @Test
     public void basicConstructorWithReloadOnExpiry() {
-        final ReadOnlyExpiringHashSetBuilder<String> builder = new ReadOnlyExpiringHashSetBuilder<String>(this);
+        final ReadOnlyExpiringHashSetBuilder<String> builder = new ReadOnlyExpiringHashSetBuilder<>(this);
         builder.expiryTimeoutMilliseconds(1000);
         builder.loadOnFirstAccess(false);
         builder.reloadOnExpiry(true);
@@ -152,7 +152,7 @@ public class ReadOnlyExpiringHashSetTest implements SetLoader<String>, TimeProvi
         builder.timeProvider(this);
         builder.id("Greetings");
 
-        final ReadOnlyExpiringSet<String> ims = new ReadOnlyExpiringHashSet<String>(builder);
+        final ReadOnlyExpiringSet<String> ims = new ReadOnlyExpiringHashSet<>(builder);
 
         assertEquals("Should have called load immediately", 1, reloadCount);
 

--- a/utils/src/test/java/net/objectlab/kit/util/ObjectHolderTest.java
+++ b/utils/src/test/java/net/objectlab/kit/util/ObjectHolderTest.java
@@ -9,25 +9,25 @@ public class ObjectHolderTest {
 
     @Test
     public void testObjectHolder() {
-        final ObjectHolder<Integer> it = new ObjectHolder<Integer>();
+        final ObjectHolder<Integer> it = new ObjectHolder<>();
         assertNull(it.getValue());
     }
 
     @Test
     public void testObjectHolderT() {
-        final ObjectHolder<Integer> it = new ObjectHolder<Integer>(Integer.valueOf(987987));
+        final ObjectHolder<Integer> it = new ObjectHolder<>(Integer.valueOf(987987));
         assertEquals("value", Integer.valueOf(987987), it.getValue());
     }
 
     @Test
     public void testSetValue() {
-        final ObjectHolder<Integer> it = new ObjectHolder<Integer>();
+        final ObjectHolder<Integer> it = new ObjectHolder<>();
         assertNull(it.getValue());
         final Integer val = Integer.valueOf(9879872);
         it.setValue(val);
         assertEquals("value 1", val, it.getValue());
 
-        final ObjectHolder<Integer> it2 = new ObjectHolder<Integer>(Integer.valueOf(987987));
+        final ObjectHolder<Integer> it2 = new ObjectHolder<>(Integer.valueOf(987987));
         assertEquals("value 2", Integer.valueOf(987987), it2.getValue());
         it.setValue(val);
         assertEquals("value 3", val, it.getValue());

--- a/utils/src/test/java/net/objectlab/kit/util/example/PairExample.java
+++ b/utils/src/test/java/net/objectlab/kit/util/example/PairExample.java
@@ -11,7 +11,7 @@ public class PairExample {
         final Pair<String, BigDecimal> p1 = Pair.create("AMGN", new BigDecimal("114.13"));
         final Pair<String, BigDecimal> p2 = Pair.create("AAPL", new BigDecimal("614.88"));
         final Pair<String, BigDecimal> p3 = Pair.create("AAPL", new BigDecimal("614.88"));
-        final Set<Pair<String, BigDecimal>> set = new HashSet<Pair<String, BigDecimal>>();
+        final Set<Pair<String, BigDecimal>> set = new HashSet<>();
         set.add(p1);
         set.add(p2);
         set.add(p3);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - The diamond operator ("<>") should be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2293

Please let me know if you have any questions.

M-Ezzat