### PR TITLE
Multiple quality improvements - squid:S2162, squid:S2131, pmd:Immutab…

### DIFF
--- a/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/Tenor.java
+++ b/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/Tenor.java
@@ -43,7 +43,7 @@ import java.io.Serializable;
  */
 public class Tenor implements Serializable {
     private static final long serialVersionUID = 1L;
-    private int units;
+    private final int units;
 
     private final TenorCode code;
 
@@ -66,7 +66,7 @@ public class Tenor implements Serializable {
 
     @Override
     public String toString() {
-        return (units != 0 ? "" + units : "") + code.getCode();
+        return (units != 0 ? String.valueOf(units) : "") + code.getCode();
     }
 
     // -----------------------------------------------------------------------

--- a/utils/src/main/java/net/objectlab/kit/util/Quadruplet.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Quadruplet.java
@@ -101,7 +101,7 @@ public class Quadruplet<E1, E2, E3, E4> implements Serializable {
         if (rhs == null) {
             return false;
         }
-        if (!(rhs instanceof Quadruplet)) {
+        if (this.getClass() != rhs.getClass()) {
             return false;
         }
         final Quadruplet<?, ?, ?, ?> that = (Quadruplet<?, ?, ?, ?>) rhs;

--- a/utils/src/main/java/net/objectlab/kit/util/Triplet.java
+++ b/utils/src/main/java/net/objectlab/kit/util/Triplet.java
@@ -91,7 +91,7 @@ public class Triplet<E1, E2, E3> implements Serializable {
         if (rhs == null) {
             return false;
         }
-        if (!(rhs instanceof Triplet)) {
+        if (this.getClass() != rhs.getClass()) {
             return false;
         }
         final Triplet<?, ?, ?> that = (Triplet<?, ?, ?>) rhs;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2162 - "equals" methods should be symmetric and work for subclasses
squid:S2131 - Primitives should not be boxed just for "String" conversion
pmd:ImmutableField - Immutable Field


You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131
https://dev.eclipse.org/sonar/coding_rules#q=pmd:ImmutableField

Please let me know if you have any questions.

M-Ezzat