### PR TITLE
Fix bug when calculating OVERNIGHT and TOM in calculateTenorDate

### DIFF
--- a/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/ccy/AbstractCurrencyDateCalculator.java
+++ b/datecalc-common/src/main/java/net/objectlab/kit/datecalc/common/ccy/AbstractCurrencyDateCalculator.java
@@ -274,11 +274,9 @@ public abstract class AbstractCurrencyDateCalculator<E extends Serializable> imp
         // move by tenor
         switch (tenorCode) {
         case OVERNIGHT:
-            calc = calculateNextDay(calc);
             calc = adjustForCcyPairIfRequired(calc);
             break;
         case TOM_NEXT: // it would have NOT moved by
-            calc = calculateNextDay(calc);
             calc = calculateNextDay(calc);
             calc = adjustForCcyPairIfRequired(calc);
             break;

--- a/datecalc-common/src/test/java/net/objectlab/kit/datecalc/common/AbstractCurrencyDateCalculatorTest.java
+++ b/datecalc-common/src/test/java/net/objectlab/kit/datecalc/common/AbstractCurrencyDateCalculatorTest.java
@@ -88,6 +88,24 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
         checkDate("Spot", cal.calculateSpotDate(newDate("2006-08-05")), "2006-08-09"); // Sat (move to Mon) -> Wed
     }
 
+    public void testSimpleTodayUsdEur() {
+        final CurrencyDateCalculator<E> cal = newCurrencyCalculator(CurrencyDateCalculator.USD_CODE, "EUR");
+        Assert.assertEquals("Name", "USD.EUR", cal.getName());
+
+        checkDate("Spot", cal.calculateTenorDate(newDate("2006-08-01"), StandardTenor.OVERNIGHT), "2006-08-01"); // Tues->Tues
+    }
+
+    public void testSimpleTomUsdEur() {
+        final CurrencyDateCalculator<E> cal = newCurrencyCalculator(CurrencyDateCalculator.USD_CODE, "EUR");
+        Assert.assertEquals("Name", "USD.EUR", cal.getName());
+
+        final Tenor tom = new Tenor(0, TenorCode.TOM_NEXT);
+
+        checkDate("Spot", cal.calculateTenorDate(newDate("2006-08-01"), tom), "2006-08-02"); // Tues-> Wed
+        checkDate("Spot", cal.calculateTenorDate(newDate("2006-08-04"), tom), "2006-08-07"); // Fri -> Mon
+    }
+
+
     /*
      * July 2006
      * Su Mo Tu We Th Fr Sa
@@ -201,33 +219,33 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
         checkDate("1M from 28-Oct-2014", t1mDate, "2014-12-01"); // ALLOWED to Cross over to next month
     }
     /*
-    
+
     public void testSimpleForwardStartDateWithWeekend() {
         final CurrencyDateCalculator<E> cal = newCurrencyCalculator(CurrencyDateCalculator.USD_CODE, "EUR");
         Assert.assertEquals("Name", "USD.EUR", cal.getName());
-    
+
         cal.setStartDate(newDate("2006-07-31")); // start date Monday
         checkDate("start date Monday", cal, "2006-07-31");
-    
+
         cal.setStartDate(newDate("2006-08-01")); // start date Tuesday
         checkDate("start date Tuesday", cal, "2006-08-01");
-    
+
         cal.setStartDate(newDate("2006-08-02")); // start date Wednesday
         checkDate("start date Wednesday", cal, "2006-08-02");
-    
+
         cal.setStartDate(newDate("2006-08-03")); // start date Thursday
         checkDate("start date Thursday", cal, "2006-08-03");
-    
+
         cal.setStartDate(newDate("2006-08-04")); // set on a Friday
         checkDate("start date friday", cal, "2006-08-04");
-    
+
         cal.setStartDate(newDate("2006-08-05")); // set on a Saturday
         checkDate("start date Saturday", cal, "2006-08-07");
-    
+
         cal.setStartDate(newDate("2006-08-06")); // set on a Sunday
         checkDate("start date Sunday", cal, "2006-08-07");
     }
-    
+
     public void testSimpleForwardStartDateNoWeekend() {
         final CurrencyDateCalculator<E> cal = newCurrencyCalculator(CurrencyDateCalculator.USD_CODE, "EUR");
         Assert.assertEquals("Name", "USD.EUR", cal.getName());
@@ -235,117 +253,117 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
                 .withWorkingDayFromCalendar(true, Calendar.SUNDAY);
         cal.setWorkingWeek(getWorkingWeek(ww));
         Assert.assertEquals("Holidays size", 0, cal.getHolidayCalendar().getHolidays().size());
-    
+
         cal.setStartDate(newDate("2006-07-31")); // start date Monday
         checkDate("start date Monday", cal, "2006-07-31");
-    
+
         cal.setStartDate(newDate("2006-08-01")); // start date Tuesday
         checkDate("start date Tuesday", cal, "2006-08-01");
-    
+
         cal.setStartDate(newDate("2006-08-02")); // start date Wednesday
         checkDate("start date Wednesday", cal, "2006-08-02");
-    
+
         cal.setStartDate(newDate("2006-08-03")); // start date Thursday
         checkDate("start date Thursday", cal, "2006-08-03");
-    
+
         cal.setStartDate(newDate("2006-08-04")); // set on a Friday
         checkDate("start date friday", cal, "2006-08-04");
-    
+
         cal.setStartDate(newDate("2006-08-05")); // set on a Saturday
         checkDate("start date Saturday", cal, "2006-08-05");
-    
+
         cal.setStartDate(newDate("2006-08-06")); // set on a Sunday
         checkDate("start date Sunday", cal, "2006-08-06");
     }
-    
+
     public void testSimpleForwardStartDateWhackyWeek() {
         final CurrencyDateCalculator<E> cal = newCurrencyCalculator(CurrencyDateCalculator.USD_CODE, "EUR");
         Assert.assertEquals("Name", "USD.EUR", cal.getName());
-    
+
         final WorkingWeek ww = new WorkingWeek().withWorkingDayFromCalendar(false, Calendar.MONDAY)
                 .withWorkingDayFromCalendar(true, Calendar.TUESDAY).withWorkingDayFromCalendar(false, Calendar.WEDNESDAY)
                 .withWorkingDayFromCalendar(true, Calendar.THURSDAY).withWorkingDayFromCalendar(false, Calendar.FRIDAY)
                 .withWorkingDayFromCalendar(true, Calendar.SATURDAY).withWorkingDayFromCalendar(false, Calendar.SUNDAY);
         cal.setWorkingWeek(getWorkingWeek(ww));
-    
+
         cal.setStartDate(newDate("2006-07-31")); // start date Monday
         checkDate("start date Monday", cal, "2006-08-01");
-    
+
         cal.setStartDate(newDate("2006-08-01")); // start date Tuesday
         checkDate("start date Tuesday", cal, "2006-08-01");
-    
+
         cal.setStartDate(newDate("2006-08-02")); // start date Wednesday
         checkDate("start date Wednesday", cal, "2006-08-03");
-    
+
         cal.setStartDate(newDate("2006-08-03")); // start date Thursday
         checkDate("start date Thursday", cal, "2006-08-03");
-    
+
         cal.setStartDate(newDate("2006-08-04")); // set on a Friday
         checkDate("start date friday", cal, "2006-08-05");
-    
+
         cal.setStartDate(newDate("2006-08-05")); // set on a Saturday
         checkDate("start date Saturday", cal, "2006-08-05");
-    
+
         cal.setStartDate(newDate("2006-08-06")); // set on a Sunday
         checkDate("start date Sunday", cal, "2006-08-08");
     }
-    
+
     public void testSimpleForwardStartDateIdealWeekend() {
         final CurrencyDateCalculator<E> cal = newCurrencyCalculator(CurrencyDateCalculator.USD_CODE, "EUR");
         Assert.assertEquals("Name", "USD.EUR", cal.getName());
         Assert.assertEquals("Holidays size", 0, cal.getHolidayCalendar().getHolidays().size());
-    
+
         final WorkingWeek ww = new WorkingWeek().withWorkingDayFromCalendar(false, Calendar.MONDAY)
                 .withWorkingDayFromCalendar(true, Calendar.TUESDAY).withWorkingDayFromCalendar(true, Calendar.WEDNESDAY)
                 .withWorkingDayFromCalendar(true, Calendar.THURSDAY).withWorkingDayFromCalendar(true, Calendar.FRIDAY)
                 .withWorkingDayFromCalendar(false, Calendar.SATURDAY).withWorkingDayFromCalendar(false, Calendar.SUNDAY);
         cal.setWorkingWeek(getWorkingWeek(ww));
-    
+
         cal.setStartDate(newDate("2006-07-31")); // start date Monday
         checkDate("start date Monday", cal, "2006-08-01");
-    
+
         cal.setStartDate(newDate("2006-08-01")); // start date Tuesday
         checkDate("start date Tuesday", cal, "2006-08-01");
-    
+
         cal.setStartDate(newDate("2006-08-02")); // start date Wednesday
         checkDate("start date Wednesday", cal, "2006-08-02");
-    
+
         cal.setStartDate(newDate("2006-08-03")); // start date Thursday
         checkDate("start date Thursday", cal, "2006-08-03");
-    
+
         cal.setStartDate(newDate("2006-08-04")); // set on a Friday
         checkDate("start date friday", cal, "2006-08-04");
-    
+
         cal.setStartDate(newDate("2006-08-05")); // set on a Saturday
         checkDate("start date Saturday", cal, "2006-08-08");
-    
+
         cal.setStartDate(newDate("2006-08-06")); // set on a Sunday
         checkDate("start date Sunday", cal, "2006-08-08");
     }
-    
+
     public void testSimpleForwardWithHolidays() {
         final CurrencyDateCalculator<E> cal = newCurrencyCalculator(CurrencyDateCalculator.USD_CODE, "GBP");
         Assert.assertEquals("Name", "USD.GBP", cal.getName());
-    
+
         cal.setStartDate(newDate("2006-08-28"));
         checkDate("Move given Bank Holiday", cal, "2006-08-29");
-    
+
         cal.setStartDate(newDate("2006-12-24"));
         checkDate("Xmas Eve", cal, "2006-12-27");
-    
+
         cal.setStartDate(newDate("2006-12-21"));
         checkDate("21/12 + 1", cal.moveByDays(1), "2006-12-22");
-    
+
         cal.setStartDate(newDate("2006-12-21"));
         checkDate("21/12 + 1", cal.moveByDays(2), "2006-12-27");
-    
+
         cal.setStartDate(newDate("2006-12-22"));
         checkDate("22/12 + 1", cal.moveByDays(1), "2006-12-27");
-    
+
         cal.setStartDate(newDate("2006-12-23"));
         checkDate("23/12 + 1", cal.moveByDays(1), "2006-12-28");
     }
-    
+
     // -----------------------------------------------------------------------
     //
     // ObjectLab, world leaders in the design and development of bespoke
@@ -353,43 +371,43 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
     // www.ObjectLab.co.uk
     //
     // -----------------------------------------------------------------------
-    
+
     public void testMoveByBusinessDays() {
         final CurrencyDateCalculator<E> cal = newCurrencyCalculator(CurrencyDateCalculator.USD_CODE, "GBP");
         Assert.assertEquals("Name", "USD.GBP", cal.getName());
-    
+
         cal.setStartDate(newDate("2006-08-24"));
         checkDate("Move 1 BD", cal.moveByBusinessDays(1), "2006-08-25");
-    
+
         cal.setStartDate(newDate("2006-08-24"));
         checkDate("Add 1 week", cal.moveByDays(7), "2006-08-31");
         cal.setStartDate(newDate("2006-08-24"));
         checkDate("Move by 1W with 1 bank holiday", cal.moveByBusinessDays(7), "2006-09-05");
-    
+
     }
-    
+
     protected void checkMoveByTenor(final String ccy1, final String ccy2, final String startDate, final Tenor tenor, final int spotLag,
             final String expectedDate) {
         final CurrencyDateCalculator<E> cal = newCurrencyCalculator(ccy1, ccy2);
         cal.setStartDate(newDate(startDate));
         checkDate("Move start:" + startDate + " tenor:" + tenor + " daysToSpot:" + spotLag, cal.moveByTenor(tenor, spotLag), expectedDate);
     }
-    
+
     protected void checkMoveByTenor(final String ccy1, final String ccy2, final String startDate, final Tenor tenor, final String expectedDate,
             final String holidayHandlerType) {
         final CurrencyDateCalculator<E> cal = newCurrencyCalculator(ccy1, ccy2);
         cal.setStartDate(newDate(startDate));
         checkDate("Move start:" + startDate + " tenor:" + tenor, cal.moveByTenor(tenor), expectedDate);
     }
-    
+
     public void testMoveByTenorDaysZeroDayToSpot() {
         checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "RUB", "2006-08-08", StandardTenor.SPOT, 0, "2006-08-08");
         checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "RUB", "2006-01-06", StandardTenor.SPOT, 0, "2006-01-09"); // moved to Monday
-    
+
         checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "RUB", "2006-08-08", new Tenor(2, TenorCode.DAY), 0, "2006-08-10");
         checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "RUB", "2006-01-06", new Tenor(2, TenorCode.DAY), 0, "2006-01-11");
     }
-    
+
     /*
          July 2006
     Su Mo Tu We Th Fr Sa
@@ -399,7 +417,7 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
     16 17 18 19 20 21 22
     23 24 25 26 27 28 29
     30 31
-    
+
     August 2006
     Su Mo Tu We Th Fr Sa
     ..  .  1  2  3  4  5
@@ -417,7 +435,7 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
         checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "CAD", "2006-07-01", StandardTenor.SPOT, 1, "2006-07-05");
         checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "CAD", "2006-07-01", new Tenor(2, TenorCode.DAY), 1, "2006-07-07");
     }
-    
+
     public void testMoveByTenorDaysTwoDaysToSpot() {
         // US holiday on 4 July!
         checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "EUR", "2006-06-30", StandardTenor.SPOT, 2, "2006-07-05");
@@ -426,29 +444,29 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
         checkMoveByTenor("EUR", CurrencyDateCalculator.USD_CODE, "2006-07-03", StandardTenor.SPOT, 2, "2006-07-05");
         checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "EUR", "2006-07-04", StandardTenor.SPOT, 2, "2006-07-07");
         checkMoveByTenor("EUR", CurrencyDateCalculator.USD_CODE, "2006-07-04", StandardTenor.SPOT, 2, "2006-07-07");
-    
+
         checkMoveByTenor("EUR", CurrencyDateCalculator.USD_CODE, "2005-12-30", StandardTenor.SPOT, 2, "2006-01-04");
         checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "EUR", "2005-12-30", StandardTenor.SPOT, 2, "2006-01-04");
-    
+
         // cross Ccy with US Bank holiday on T+1 but it should not impact it
         checkMoveByTenor("GBP", "EUR", "2006-07-03", StandardTenor.SPOT, 2, "2006-07-05");
         checkMoveByTenor("EUR", "GBP", "2006-07-03", StandardTenor.SPOT, 2, "2006-07-05");
-    
+
         // cross Ccy with US Bank holiday on T+1 BUT ARS!!!
         checkMoveByTenor("ARS", "EUR", "2006-07-03", StandardTenor.SPOT, 2, "2006-07-06");
         checkMoveByTenor("EUR", "ARS", "2006-07-03", StandardTenor.SPOT, 2, "2006-07-06");
-    
+
         // cross Ccy with US Bank holiday on T+1 BUT MXN!!! And MXN is on Holiday on 6 July
         checkMoveByTenor("MXN", "EUR", "2006-07-03", StandardTenor.SPOT, 2, "2006-07-07");
         checkMoveByTenor("EUR", "MXN", "2006-07-03", StandardTenor.SPOT, 2, "2006-07-07");
-    
+
         // checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "EUR", "2006-08-08", new Tenor(2, TenorCode.DAY), 2, "2006-08-14");
         // checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "EUR", "2006-08-07", new Tenor(10, TenorCode.DAY), 2, "2006-08-21");
         // checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "EUR", "2006-08-07", new Tenor(11, TenorCode.DAY), 2, "2006-08-21");
         // checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "EUR", "2006-08-07", new Tenor(12, TenorCode.DAY), 2, "2006-08-21");
         // checkMoveByTenor(CurrencyDateCalculator.USD_CODE, "EUR", "2006-08-07", new Tenor(13, TenorCode.DAY), 2, "2006-08-22");
     }
-    
+
     public void testCalculateTenorsZeroDaysToSpot() {
         final List<Tenor> list = new ArrayList<Tenor>();
         list.add(StandardTenor.OVERNIGHT);
@@ -462,7 +480,7 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
         list.add(StandardTenor.T_6M);
         list.add(StandardTenor.T_9M);
         list.add(StandardTenor.T_1Y);
-    
+
         final CurrencyDateCalculator<E> cal = newCurrencyCalculator(CurrencyDateCalculator.USD_CODE, "GBP");
         final String startDate = "2006-08-24";
         cal.setStartDate(newDate(startDate));
@@ -478,7 +496,7 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
         expectedResults.add(newDate("2007-02-26")); // 6M
         expectedResults.add(newDate("2007-05-24")); // 9M
         expectedResults.add(newDate("2007-08-24")); // 1Y
-    
+
         final List<E> results = cal.calculateTenorDates(list);
         assertEquals("Same size as tenor", list.size(), results.size());
         final Iterator<E> it = results.iterator();
@@ -487,7 +505,7 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
             assertEquals("Move start:" + startDate + " tenor:" + tenor, expected.next(), it.next());
         }
     }
-    
+
     public void testCalculateTenorsTwoDaysToSpot() {
         final List<Tenor> list = new ArrayList<Tenor>();
         list.add(StandardTenor.OVERNIGHT);
@@ -501,7 +519,7 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
         list.add(StandardTenor.T_6M);
         list.add(StandardTenor.T_9M);
         list.add(StandardTenor.T_1Y);
-    
+
         final CurrencyDateCalculator<E> cal = newCurrencyCalculator(CurrencyDateCalculator.USD_CODE, "GBP");
         final String startDate = "2006-08-24";
         cal.setStartDate(newDate(startDate));
@@ -517,7 +535,7 @@ public abstract class AbstractCurrencyDateCalculatorTest<E extends Serializable>
         expectedResults.add(newDate("2007-02-28")); // 6M - is this correct?
         expectedResults.add(newDate("2007-05-29")); // 9M
         expectedResults.add(newDate("2007-08-29")); // 1Y
-    
+
         final List<E> results = cal.calculateTenorDates(list, 2);
         assertEquals("Same size as tenor", list.size(), results.size());
         final Iterator<E> it = results.iterator();


### PR DESCRIPTION
calculateTenorDate method in AbstractCurrencyDateCalculator adds one day to
to the expected dates for value Today and value Tomorrow.