### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
     token:
       secure: 13b70009cbae7646c3458517212a3ba73faff609
 git:
-  depth: false
+  depth: 3
 env:
   global:
   - SONATYPE_USERNAME=benoitx


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.